### PR TITLE
Missing parens to function call interpolation

### DIFF
--- a/blade.md
+++ b/blade.md
@@ -255,7 +255,7 @@ The following example creates a `@datetime($var)` directive which formats a give
         public function boot()
         {
             Blade::directive('datetime', function($expression) {
-                return "<?php echo with{$expression}->format('m/d/Y H:i'); ?>";
+                return "<?php echo with({$expression})->format('m/d/Y H:i'); ?>";
             });
         }
 


### PR DESCRIPTION
If `$foo = 44`, "with{$foo} is `with44`, not `with(44)`